### PR TITLE
RMS updates to Investigation context products #2

### DIFF
--- a/data/pds4/context-pds4/investigation/working/mission.2001_mars_odyssey_2.1.xml
+++ b/data/pds4/context-pds4/investigation/working/mission.2001_mars_odyssey_2.1.xml
@@ -45,7 +45,7 @@
       </Modification_Detail>
       <Modification_Detail>
         <modification_date>2024-10-09</modification_date>
-        <version_id>2.0</version_id>
+        <version_id>2.1</version_id>
         <description>Adding missing "agency" references.</description>
       </Modification_Detail>
     </Modification_History>

--- a/data/pds4/context-pds4/investigation/working/mission.galileo_1.2.xml
+++ b/data/pds4/context-pds4/investigation/working/mission.galileo_1.2.xml
@@ -10,8 +10,8 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <product_class>Product_Context</product_class>
     <Alias_List>
       <Alias>
-        <alternate_id>GALILEO_MILLENNIUM_MISSION_(GMM)</alternate_id>
-        <alternate_title>GALILEO MILLENNIUM MISSION (GMM)</alternate_title>
+        <alternate_id>Galileo_Millennium_Mission_(GMM)</alternate_id>
+        <alternate_title>Galileo Millennium Mission (GMM)</alternate_title>
       </Alias>
     </Alias_List>
     <Modification_History>

--- a/data/pds4/context-pds4/investigation/working/mission.pioneer_10_1.1.xml
+++ b/data/pds4/context-pds4/investigation/working/mission.pioneer_10_1.1.xml
@@ -10,8 +10,8 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <product_class>Product_Context</product_class>
     <Alias_List>
       <Alias>
-        <alternate_id>PIONEER_F</alternate_id>
-        <alternate_title>PIONEER F</alternate_title>
+        <alternate_id>Pioneer_F</alternate_id>
+        <alternate_title>Pioneer F</alternate_title>
       </Alias>
     </Alias_List>
     <Modification_History>

--- a/data/pds4/context-pds4/investigation/working/mission.pioneer_11_1.1.xml
+++ b/data/pds4/context-pds4/investigation/working/mission.pioneer_11_1.1.xml
@@ -10,8 +10,8 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <product_class>Product_Context</product_class>
     <Alias_List>
       <Alias>
-        <alternate_id>PIONEER_G</alternate_id>
-        <alternate_title>PIONEER G</alternate_title>
+        <alternate_id>Pioneer_G</alternate_id>
+        <alternate_title>Pioneer G</alternate_title>
       </Alias>
     </Alias_List>
     <Modification_History>

--- a/data/pds4/context-pds4/investigation/working/mission.saturn_occultation_of_28_sagittarius_1989_1.1.xml
+++ b/data/pds4/context-pds4/investigation/working/mission.saturn_occultation_of_28_sagittarius_1989_1.1.xml
@@ -5,7 +5,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
   <Identification_Area>
     <logical_identifier>urn:nasa:pds:context:investigation:observing_campaign.saturn_occultation_of_28_sagittarius_1989</logical_identifier>
     <version_id>1.1</version_id>
-    <title>SATURN OCCULTATION OF 28 SAGITTARIUS 1989</title>
+    <title>Saturn Occultation of 28 Sagittarius (1989)</title>
     <information_model_version>1.22.0.0</information_model_version>
     <product_class>Product_Context</product_class>
     <Modification_History>
@@ -150,7 +150,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </External_Reference>
   </Reference_List>
   <Investigation>
-    <name>SATURN OCCULTATION OF 28 SAGITTARIUS 1989</name>
+    <name>Saturn Occultation of 28 Sagittarius (1989)</name>
     <type>Mission</type>
     <start_date>1989-07-03</start_date>
     <stop_date>1989-07-03</stop_date>

--- a/data/pds4/context-pds4/investigation/working/mission.saturn_ring_plane_crossing_1995_1.2.xml
+++ b/data/pds4/context-pds4/investigation/working/mission.saturn_ring_plane_crossing_1995_1.2.xml
@@ -3,9 +3,9 @@
 schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Context xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:pds="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1M00.xsd">
   <Identification_Area>
-    <logical_identifier>urn:nasa:pds:context:investigation:mission.saturn_ring_plane_crossing_1995</logical_identifier>
+    <logical_identifier>urn:nasa:pds:context:investigation:observing_campaign.saturn_ring_plane_crossing_1995</logical_identifier>
     <version_id>1.2</version_id>
-    <title>SATURN RING PLANE CROSSING 1995</title>
+    <title>Saturn Ring Plane Crossing (1995)</title>
     <information_model_version>1.22.0.0</information_model_version>
     <product_class>Product_Context</product_class>
     <Modification_History>
@@ -192,7 +192,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </External_Reference>
   </Reference_List>
   <Investigation>
-    <name>SATURN RING PLANE CROSSING 1995</name>
+    <name>Saturn Ring Plane Crossing (1995)</name>
     <type>Mission</type>
     <start_date>1994-01-01</start_date>
     <stop_date>1997-01-01</stop_date>

--- a/data/pds4/context-pds4/investigation/working/mission.saturn_small_satellite_astrometry_1.2.xml
+++ b/data/pds4/context-pds4/investigation/working/mission.saturn_small_satellite_astrometry_1.2.xml
@@ -3,9 +3,9 @@
 schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Context xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:pds="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1M00.xsd">
   <Identification_Area>
-    <logical_identifier>urn:nasa:pds:context:investigation:mission.saturn_small_satellite_astrometry</logical_identifier>
+    <logical_identifier>urn:nasa:pds:context:investigation:observing_campaign.saturn_small_satellite_astrometry</logical_identifier>
     <version_id>1.2</version_id>
-    <title>SATURN SMALL SATELLITE ASTROMETRY</title>
+    <title>Saturn Small Satellite Astrometry</title>
     <information_model_version>1.22.0.0</information_model_version>
     <product_class>Product_Context</product_class>
     <Modification_History>
@@ -191,7 +191,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </External_Reference>
   </Reference_List>
   <Investigation>
-    <name>SATURN SMALL SATELLITE ASTROMETRY</name>
+    <name>Saturn Small Satellite Astrometry</name>
     <type>Mission</type>
     <start_date>1994-12-01</start_date>
     <stop_date>2005-01-14</stop_date>


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Minor cleanup of Investigation context products:
- `mission.2001_mars_odyssey_2.1.xml`:  I noticed that the most recent `Modification_Detail` said it was for version 2.0 but should be 2.1
- `mission.galileo`, `mission.pioneer_10`, and `mission.pioneer_11`:  Migrated `alternate_id` and `alternate_title` from all caps to title case
- `mission.saturn_occultation_of_28_sagittarius_1989`, `mission.saturn_ring_plane_cross_1995`, and `mission.saturn_small_satellite_astrometry`:  
  - Updated `Identification_Area.title` and `Investigation.name`
  - In the LID for the latter two, changed `mission` to `observing_campaign` (this was already done for 28 Sgr)
  - Should we change the filenames accordingly?

## ⚙️ Test Data and/or Report
One of the following should be included here:
* Reference to regression test included in code (preferred wherever reasonable)
* Attach test data here + outputs of tests

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


