### PR TITLE
Context product updates for comets and field campaigns per requests from ATM and SBN

### DIFF
--- a/data/pds4/context-pds4/facility/observatory.atlas-chl_1.0.xml
+++ b/data/pds4/context-pds4/facility/observatory.atlas-chl_1.0.xml
@@ -32,6 +32,11 @@
 
   <Reference_List>
     <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:observing_campaign.atlas</lid_reference>
+      <reference_type>facility_to_investigation</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
       <lid_reference>urn:nasa:pds:context:telescope:atlas-chl.0m5</lid_reference>
       <reference_type>facility_to_telescope</reference_type>
     </Internal_Reference>

--- a/data/pds4/context-pds4/facility/observatory.atlas-cpt_1.0.xml
+++ b/data/pds4/context-pds4/facility/observatory.atlas-cpt_1.0.xml
@@ -32,6 +32,11 @@
 
   <Reference_List>
     <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:observing_campaign.atlas</lid_reference>
+      <reference_type>facility_to_investigation</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
       <lid_reference>urn:nasa:pds:context:telescope:atlas-cpt.0m5</lid_reference>
       <reference_type>facility_to_telescope</reference_type>
     </Internal_Reference>

--- a/data/pds4/context-pds4/facility/observatory.atlas-hko_1.0.xml
+++ b/data/pds4/context-pds4/facility/observatory.atlas-hko_1.0.xml
@@ -32,6 +32,11 @@
 
   <Reference_List>
     <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:observing_campaign.atlas</lid_reference>
+      <reference_type>facility_to_investigation</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
       <lid_reference>urn:nasa:pds:context:telescope:atlas-hko.0m5</lid_reference>
       <reference_type>facility_to_telescope</reference_type>
     </Internal_Reference>

--- a/data/pds4/context-pds4/facility/observatory.atlas-mlo_1.0.xml
+++ b/data/pds4/context-pds4/facility/observatory.atlas-mlo_1.0.xml
@@ -32,6 +32,11 @@
 
   <Reference_List>
     <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:observing_campaign.atlas</lid_reference>
+      <reference_type>facility_to_investigation</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
       <lid_reference>urn:nasa:pds:context:telescope:atlas-mlo.0m5</lid_reference>
       <reference_type>facility_to_telescope</reference_type>
     </Internal_Reference>

--- a/data/pds4/context-pds4/instrument/atlas-chl.0m5.sta1600_1.0.xml
+++ b/data/pds4/context-pds4/instrument/atlas-chl.0m5.sta1600_1.0.xml
@@ -30,6 +30,11 @@
 
   <Reference_List>
     <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:observing_campaign.atlas</lid_reference>
+      <reference_type>instrument_to_investigation</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
       <lid_reference>urn:nasa:pds:context:facility:observatory.atlas-chl</lid_reference>
       <reference_type>instrument_to_facility</reference_type>
     </Internal_Reference>

--- a/data/pds4/context-pds4/instrument/atlas-cpt.0m5.sta1600_1.0.xml
+++ b/data/pds4/context-pds4/instrument/atlas-cpt.0m5.sta1600_1.0.xml
@@ -30,6 +30,11 @@
 
   <Reference_List>
     <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:observing_campaign.atlas</lid_reference>
+      <reference_type>instrument_to_investigation</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
       <lid_reference>urn:nasa:pds:context:facility:observatory.atlas-cpt</lid_reference>
       <reference_type>instrument_to_facility</reference_type>
     </Internal_Reference>

--- a/data/pds4/context-pds4/instrument/atlas-hko.0m5.sta1600_1.0.xml
+++ b/data/pds4/context-pds4/instrument/atlas-hko.0m5.sta1600_1.0.xml
@@ -30,6 +30,11 @@
 
   <Reference_List>
     <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:observing_campaign.atlas</lid_reference>
+      <reference_type>instrument_to_investigation</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
       <lid_reference>urn:nasa:pds:context:facility:observatory.atlas-hko</lid_reference>
       <reference_type>instrument_to_facility</reference_type>
     </Internal_Reference>

--- a/data/pds4/context-pds4/instrument/atlas-mlo.0m5.sta1600_1.0.xml
+++ b/data/pds4/context-pds4/instrument/atlas-mlo.0m5.sta1600_1.0.xml
@@ -30,6 +30,11 @@
 
   <Reference_List>
     <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:observing_campaign.atlas</lid_reference>
+      <reference_type>instrument_to_investigation</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
       <lid_reference>urn:nasa:pds:context:facility:observatory.atlas-mlo</lid_reference>
       <reference_type>instrument_to_facility</reference_type>
     </Internal_Reference>

--- a/data/pds4/context-pds4/instrument/pvmp.lp.dlbi_1.0.xml
+++ b/data/pds4/context-pds4/instrument/pvmp.lp.dlbi_1.0.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="https://pds.nasa.gov/pds4/ctli/v2/PDS4_CTLI_1N00_2100.sch" schematypens="http://purl.oclc.org/dsdl/schematron?>
+<Product_Context xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ctli="http://pds.nasa.gov/pds4/ctli/v2"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd http://pds.nasa.gov/pds4/ctli/v2 https://pds.nasa.gov/pds4/ctli/v2/PDS4_CTLI_1N00_2100.xsd">
+
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:instrument:pvmp.lp.dlbi</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>DIFFERENTIAL LONG BASE LINE INTERFEROMETER for PIONEER VENUS LARGE PROBE</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2025-04-01</modification_date>
+        <version_id>1.0</version_id>
+        <description>
+              Initial creation
+            </description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+
+  <Reference_List>
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.pvmp.lp</lid_reference>
+      <reference_type>instrument_to_instrument_host</reference_type>
+    </Internal_Reference>
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:mission.pioneer_venus</lid_reference>
+      <reference_type>instrument_to_investigation</reference_type>
+    </Internal_Reference>
+    <External_Reference>
+      <doi>10.1126/science.203.4382.805</doi>
+      <reference_text> Counselman, C. C., III, et al., Wind velocities on Venus: Vector
+        determination by radio interferometry, Science, 203, No. 4382, 805-806, Feb. 1979.
+      </reference_text>
+    </External_Reference>
+    <External_Reference>
+      <doi>10.1029/JA085iA13p08026</doi>
+      <reference_text> Counselman, C. C., III, et al., Zonal and meridional circulation of the lower
+        atmosphere of Venus determined by radio interferometry, J. Geophys. Res., 85, No. A13,
+        8026-8031, Dec. 1980. </reference_text>
+    </External_Reference>
+    <External_Reference>
+      <doi>10.1007/BF02186463</doi>
+      <reference_text> Colin, L., Ed., and D. M. Hunten, Ed., Pioneer Venus experiment descriptions,
+        Space Sci. Rev., 20, No. 4, 451-525, June 1977. </reference_text>
+    </External_Reference>
+  </Reference_List>
+
+  <Instrument>
+    <name>PIONEER VENUS LARGE PROBE DIFFERENTIAL LONG BASE LINE INTERFEROMETER</name>
+    <Type_List_Area>
+      <ctli:Type_List>
+        <ctli:type>Radio Science</ctli:type>
+        <ctli:subtype>Interferometer</ctli:subtype>
+      </ctli:Type_List>
+    </Type_List_Area>
+    <naif_instrument_id>not applicable</naif_instrument_id>
+
+    <serial_number>not applicable</serial_number>
+
+    <description>
+
+      This experiment involved applying differential long-baseline interferometry
+      techniques to the radio signals from the entry probes and bus in order to infer or
+      place upper limits on wind speeds in the lower atmosphere. These results were used
+      in modeling the circulation patterns of Venus' atmosphere.
+
+      As the four probes descended, the Pioneer Venus Probe Bus followed a well-defined
+      ballistic trajectory above the atmosphere that was accurately known with respect to
+      the planet's surface. Probe velocities were measured relative to the Bus.
+      Additionally, four ground stations on Earth simultaneously tracked the four probes.
+      These were the 64-meter dish Goldstone and Canberra Deep Space Network (DSN)
+      stations, and the 9-meter dish Santiago (Chile) and Guam Spaceflight Tracking And
+      Data Network (STDN) stations. They covered passbands of 2291 to 2293 MHz to receive
+      signals from all four probes and the bus simultaneously. The Doppler frequency
+      shifts of the received 13 cm (S-band) signals gave the component of the velocity
+      vector along the Earth-spacecraft line of sight. The differential long-baseline
+      interferometry was used to find the other two components of the velocity vector of
+      each probe.
+
+      Measurements of the temperature and pressure taken by other instruments as the
+      probes descended were used with the interferometry results. Data taken prior to
+      probe entry were used, where feasible, to infer characteristics of Venus' gravity
+      field for use with probe entry operations as well as in later scientific evaluation.
+      Deviations of the probe trajectories from the mathematical model of their
+      trajectories in a still atmosphere were attributed to winds. Overall uncertainties
+      were estimated at 10 cm/s.
+
+      The magnitude of the wind velocity was found to be about 1 meter/s or less near the
+      surface of the planet and about 100 meters/s near 65-km altitude at all four probe
+      locations. High wind shear was measured centered at altitudes of 15, 45, and 60 km.
+      The wind velocity was uniformly directed very close to due west, except within a few
+      km of the surface.
+
+        </description>
+  </Instrument>
+</Product_Context>

--- a/data/pds4/context-pds4/instrument/pvmp.sp-day.dlbi_1.0.xml
+++ b/data/pds4/context-pds4/instrument/pvmp.sp-day.dlbi_1.0.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="https://pds.nasa.gov/pds4/ctli/v2/PDS4_CTLI_1N00_2100.sch" schematypens="http://purl.oclc.org/dsdl/schematron?>
+<Product_Context xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ctli="http://pds.nasa.gov/pds4/ctli/v2"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd http://pds.nasa.gov/pds4/ctli/v2 https://pds.nasa.gov/pds4/ctli/v2/PDS4_CTLI_1N00_2100.xsd">
+
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:instrument:pvmp.sp-day.dlbi</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>DIFFERENTIAL LONG BASE LINE INTERFEROMETER for PIONEER VENUS SMALL PROBE (DAY)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2025-04-01</modification_date>
+        <version_id>1.0</version_id>
+        <description>
+              Initial creation
+            </description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+
+  <Reference_List>
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.pvmp.sp-day</lid_reference>
+      <reference_type>instrument_to_instrument_host</reference_type>
+    </Internal_Reference>
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:mission.pioneer_venus</lid_reference>
+      <reference_type>instrument_to_investigation</reference_type>
+    </Internal_Reference>
+    <External_Reference>
+      <doi>10.1126/science.203.4382.805</doi>
+      <reference_text> Counselman, C. C., III, et al., Wind velocities on Venus: Vector
+        determination by radio interferometry, Science, 203, No. 4382, 805-806, Feb. 1979.
+      </reference_text>
+    </External_Reference>
+    <External_Reference>
+      <doi>10.1029/JA085iA13p08026</doi>
+      <reference_text> Counselman, C. C., III, et al., Zonal and meridional circulation of the lower
+        atmosphere of Venus determined by radio interferometry, J. Geophys. Res., 85, No. A13,
+        8026-8031, Dec. 1980. </reference_text>
+    </External_Reference>
+    <External_Reference>
+      <doi>10.1007/BF02186463</doi>
+      <reference_text> Colin, L., Ed., and D. M. Hunten, Ed., Pioneer Venus experiment descriptions,
+        Space Sci. Rev., 20, No. 4, 451-525, June 1977. </reference_text>
+    </External_Reference>
+  </Reference_List>
+
+  <Instrument>
+    <name>PIONEER VENUS SMALL PROBE (DAY) DIFFERENTIAL LONG BASE LINE INTERFEROMETER</name>
+    <Type_List_Area>
+      <ctli:Type_List>
+        <ctli:type>Radio Science</ctli:type>
+        <ctli:subtype>Interferometer</ctli:subtype>
+      </ctli:Type_List>
+    </Type_List_Area>
+    <naif_instrument_id>not applicable</naif_instrument_id>
+
+    <serial_number>not applicable</serial_number>
+
+    <description>
+
+      This experiment involved applying differential long-baseline interferometry
+      techniques to the radio signals from the entry probes and bus in order to infer or
+      place upper limits on wind speeds in the lower atmosphere. These results were used
+      in modeling the circulation patterns of Venus' atmosphere.
+
+      As the four probes descended, the Pioneer Venus Probe Bus followed a well-defined
+      ballistic trajectory above the atmosphere that was accurately known with respect to
+      the planet's surface. Probe velocities were measured relative to the Bus.
+      Additionally, four ground stations on Earth simultaneously tracked the four probes.
+      These were the 64-meter dish Goldstone and Canberra Deep Space Network (DSN)
+      stations, and the 9-meter dish Santiago (Chile) and Guam Spaceflight Tracking And
+      Data Network (STDN) stations. They covered passbands of 2291 to 2293 MHz to receive
+      signals from all four probes and the bus simultaneously. The Doppler frequency
+      shifts of the received 13 cm (S-band) signals gave the component of the velocity
+      vector along the Earth-spacecraft line of sight. The differential long-baseline
+      interferometry was used to find the other two components of the velocity vector of
+      each probe.
+
+      Measurements of the temperature and pressure taken by other instruments as the
+      probes descended were used with the interferometry results. Data taken prior to
+      probe entry were used, where feasible, to infer characteristics of Venus' gravity
+      field for use with probe entry operations as well as in later scientific evaluation.
+      Deviations of the probe trajectories from the mathematical model of their
+      trajectories in a still atmosphere were attributed to winds. Overall uncertainties
+      were estimated at 10 cm/s.
+
+      The magnitude of the wind velocity was found to be about 1 meter/s or less near the
+      surface of the planet and about 100 meters/s near 65-km altitude at all four probe
+      locations. High wind shear was measured centered at altitudes of 15, 45, and 60 km.
+      The wind velocity was uniformly directed very close to due west, except within a few
+      km of the surface.
+
+        </description>
+  </Instrument>
+</Product_Context>

--- a/data/pds4/context-pds4/instrument/pvmp.sp-night.dlbi_1.0.xml
+++ b/data/pds4/context-pds4/instrument/pvmp.sp-night.dlbi_1.0.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="https://pds.nasa.gov/pds4/ctli/v2/PDS4_CTLI_1N00_2100.sch" schematypens="http://purl.oclc.org/dsdl/schematron?>
+<Product_Context xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ctli="http://pds.nasa.gov/pds4/ctli/v2"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd http://pds.nasa.gov/pds4/ctli/v2 https://pds.nasa.gov/pds4/ctli/v2/PDS4_CTLI_1N00_2100.xsd">
+
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:instrument:pvmp.sp-night.dlbi</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>DIFFERENTIAL LONG BASE LINE INTERFEROMETER for PIONEER VENUS SMALL PROBE (NIGHT)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2025-04-01</modification_date>
+        <version_id>1.0</version_id>
+        <description>
+              Initial creation
+            </description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+
+  <Reference_List>
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.pvmp.sp-night</lid_reference>
+      <reference_type>instrument_to_instrument_host</reference_type>
+    </Internal_Reference>
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:mission.pioneer_venus</lid_reference>
+      <reference_type>instrument_to_investigation</reference_type>
+    </Internal_Reference>
+    <External_Reference>
+      <doi>10.1126/science.203.4382.805</doi>
+      <reference_text> Counselman, C. C., III, et al., Wind velocities on Venus: Vector
+        determination by radio interferometry, Science, 203, No. 4382, 805-806, Feb. 1979.
+      </reference_text>
+    </External_Reference>
+    <External_Reference>
+      <doi>10.1029/JA085iA13p08026</doi>
+      <reference_text> Counselman, C. C., III, et al., Zonal and meridional circulation of the lower
+        atmosphere of Venus determined by radio interferometry, J. Geophys. Res., 85, No. A13,
+        8026-8031, Dec. 1980. </reference_text>
+    </External_Reference>
+    <External_Reference>
+      <doi>10.1007/BF02186463</doi>
+      <reference_text> Colin, L., Ed., and D. M. Hunten, Ed., Pioneer Venus experiment descriptions,
+        Space Sci. Rev., 20, No. 4, 451-525, June 1977. </reference_text>
+    </External_Reference>
+  </Reference_List>
+
+  <Instrument>
+    <name>PIONEER VENUS SMALL PROBE (NIGHT) DIFFERENTIAL LONG BASE LINE INTERFEROMETER</name>
+    <Type_List_Area>
+      <ctli:Type_List>
+        <ctli:type>Radio Science</ctli:type>
+        <ctli:subtype>Interferometer</ctli:subtype>
+      </ctli:Type_List>
+    </Type_List_Area>
+    <naif_instrument_id>not applicable</naif_instrument_id>
+
+    <serial_number>not applicable</serial_number>
+
+    <description>
+
+      This experiment involved applying differential long-baseline interferometry
+      techniques to the radio signals from the entry probes and bus in order to infer or
+      place upper limits on wind speeds in the lower atmosphere. These results were used
+      in modeling the circulation patterns of Venus' atmosphere.
+
+      As the four probes descended, the Pioneer Venus Probe Bus followed a well-defined
+      ballistic trajectory above the atmosphere that was accurately known with respect to
+      the planet's surface. Probe velocities were measured relative to the Bus.
+      Additionally, four ground stations on Earth simultaneously tracked the four probes.
+      These were the 64-meter dish Goldstone and Canberra Deep Space Network (DSN)
+      stations, and the 9-meter dish Santiago (Chile) and Guam Spaceflight Tracking And
+      Data Network (STDN) stations. They covered passbands of 2291 to 2293 MHz to receive
+      signals from all four probes and the bus simultaneously. The Doppler frequency
+      shifts of the received 13 cm (S-band) signals gave the component of the velocity
+      vector along the Earth-spacecraft line of sight. The differential long-baseline
+      interferometry was used to find the other two components of the velocity vector of
+      each probe.
+
+      Measurements of the temperature and pressure taken by other instruments as the
+      probes descended were used with the interferometry results. Data taken prior to
+      probe entry were used, where feasible, to infer characteristics of Venus' gravity
+      field for use with probe entry operations as well as in later scientific evaluation.
+      Deviations of the probe trajectories from the mathematical model of their
+      trajectories in a still atmosphere were attributed to winds. Overall uncertainties
+      were estimated at 10 cm/s.
+
+      The magnitude of the wind velocity was found to be about 1 meter/s or less near the
+      surface of the planet and about 100 meters/s near 65-km altitude at all four probe
+      locations. High wind shear was measured centered at altitudes of 15, 45, and 60 km.
+      The wind velocity was uniformly directed very close to due west, except within a few
+      km of the surface.
+
+        </description>
+  </Instrument>
+</Product_Context>

--- a/data/pds4/context-pds4/instrument/pvmp.sp-north.dlbi_1.0.xml
+++ b/data/pds4/context-pds4/instrument/pvmp.sp-north.dlbi_1.0.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="https://pds.nasa.gov/pds4/ctli/v2/PDS4_CTLI_1N00_2100.sch" schematypens="http://purl.oclc.org/dsdl/schematron?>
+<Product_Context xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ctli="http://pds.nasa.gov/pds4/ctli/v2"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd http://pds.nasa.gov/pds4/ctli/v2 https://pds.nasa.gov/pds4/ctli/v2/PDS4_CTLI_1N00_2100.xsd">
+
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:instrument:pvmp.sp-north.dlbi</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>DIFFERENTIAL LONG BASE LINE INTERFEROMETER for PIONEER VENUS SMALL PROBE (NORTH)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2025-04-01</modification_date>
+        <version_id>1.0</version_id>
+        <description>
+              Initial creation
+            </description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+
+  <Reference_List>
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.pvmp.sp-north</lid_reference>
+      <reference_type>instrument_to_instrument_host</reference_type>
+    </Internal_Reference>
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:mission.pioneer_venus</lid_reference>
+      <reference_type>instrument_to_investigation</reference_type>
+    </Internal_Reference>
+    <External_Reference>
+      <doi>10.1126/science.203.4382.805</doi>
+      <reference_text> Counselman, C. C., III, et al., Wind velocities on Venus: Vector
+        determination by radio interferometry, Science, 203, No. 4382, 805-806, Feb. 1979.
+      </reference_text>
+    </External_Reference>
+    <External_Reference>
+      <doi>10.1029/JA085iA13p08026</doi>
+      <reference_text> Counselman, C. C., III, et al., Zonal and meridional circulation of the lower
+        atmosphere of Venus determined by radio interferometry, J. Geophys. Res., 85, No. A13,
+        8026-8031, Dec. 1980. </reference_text>
+    </External_Reference>
+    <External_Reference>
+      <doi>10.1007/BF02186463</doi>
+      <reference_text> Colin, L., Ed., and D. M. Hunten, Ed., Pioneer Venus experiment descriptions,
+        Space Sci. Rev., 20, No. 4, 451-525, June 1977. </reference_text>
+    </External_Reference>
+  </Reference_List>
+
+  <Instrument>
+    <name>PIONEER VENUS SMALL PROBE (NORTH) DIFFERENTIAL LONG BASE LINE INTERFEROMETER</name>
+    <Type_List_Area>
+      <ctli:Type_List>
+        <ctli:type>Radio Science</ctli:type>
+        <ctli:subtype>Interferometer</ctli:subtype>
+      </ctli:Type_List>
+    </Type_List_Area>
+    <naif_instrument_id>not applicable</naif_instrument_id>
+
+    <serial_number>not applicable</serial_number>
+
+    <description>
+
+      This experiment involved applying differential long-baseline interferometry
+      techniques to the radio signals from the entry probes and bus in order to infer or
+      place upper limits on wind speeds in the lower atmosphere. These results were used
+      in modeling the circulation patterns of Venus' atmosphere.
+
+      As the four probes descended, the Pioneer Venus Probe Bus followed a well-defined
+      ballistic trajectory above the atmosphere that was accurately known with respect to
+      the planet's surface. Probe velocities were measured relative to the Bus.
+      Additionally, four ground stations on Earth simultaneously tracked the four probes.
+      These were the 64-meter dish Goldstone and Canberra Deep Space Network (DSN)
+      stations, and the 9-meter dish Santiago (Chile) and Guam Spaceflight Tracking And
+      Data Network (STDN) stations. They covered passbands of 2291 to 2293 MHz to receive
+      signals from all four probes and the bus simultaneously. The Doppler frequency
+      shifts of the received 13 cm (S-band) signals gave the component of the velocity
+      vector along the Earth-spacecraft line of sight. The differential long-baseline
+      interferometry was used to find the other two components of the velocity vector of
+      each probe.
+
+      Measurements of the temperature and pressure taken by other instruments as the
+      probes descended were used with the interferometry results. Data taken prior to
+      probe entry were used, where feasible, to infer characteristics of Venus' gravity
+      field for use with probe entry operations as well as in later scientific evaluation.
+      Deviations of the probe trajectories from the mathematical model of their
+      trajectories in a still atmosphere were attributed to winds. Overall uncertainties
+      were estimated at 10 cm/s.
+
+      The magnitude of the wind velocity was found to be about 1 meter/s or less near the
+      surface of the planet and about 100 meters/s near 65-km altitude at all four probe
+      locations. High wind shear was measured centered at altitudes of 15, 45, and 60 km.
+      The wind velocity was uniformly directed very close to due west, except within a few
+      km of the surface.
+
+        </description>
+  </Instrument>
+</Product_Context>

--- a/data/pds4/context-pds4/instrument_host/spacecraft.pvmp.lp_2.0.xml
+++ b/data/pds4/context-pds4/instrument_host/spacecraft.pvmp.lp_2.0.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context xmlns="http://pds.nasa.gov/pds4/pds/v1"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+    
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:context:instrument_host:spacecraft.pvmp.lp</logical_identifier>
+        <version_id>2.0</version_id>
+        <title>PIONEER VENUS LARGE PROBE</title>
+        <information_model_version>1.23.0.0</information_model_version>
+        <product_class>Product_Context</product_class>
+        <Alias_List>
+            <Alias>
+                <alternate_title>PIONEER VENUS SOUNDER PROBE</alternate_title>
+            </Alias>
+        </Alias_List>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2025-04-01</modification_date>
+                <version_id>2.0</version_id>
+                <description>Added reference for DLBI instrument</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2024-12-18</modification_date>
+                <version_id>1.1</version_id>
+                <description>Updated schema version. Adding missing "instrument" references. Description updated. At Lynn Neakrase's request, removed naif_host_id and changed name from PIONEER VENUS MULTIPROBE to PIONEER VENUS LARGE PROBE.</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2023-12-11</modification_date>
+                <version_id>1.0</version_id>
+                <description>Initial creation of the Multiprobe context products</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+
+    <Reference_List>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:investigation:mission.pioneer_venus</lid_reference>
+            <reference_type>instrument_host_to_investigation</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.lp.dlbi</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.lp.las</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.lp.lcps</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.lp.lgc</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.lp.lir</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.lp.ln</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.lp.lnms</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.lp.lsfr</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+<!--        <Internal_Reference> -->
+<!--            <lid_reference>urn:nasa:pds:context:instrument:pvmp.lp.mpro</lid_reference> -->
+<!--            <reference_type>instrument_host_to_instrument</reference_type> -->
+<!--        </Internal_Reference> -->
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:target:planet.venus</lid_reference>
+            <reference_type>instrument_host_to_target</reference_type>
+        </Internal_Reference>
+        <External_Reference>
+            <doi>10.1126/science.205.4401.41</doi>
+            <reference_text>
+                Donahue, T. M., Pioneer Venus results: An overview, Science, 205, No. 4401, 41-44, 
+                doi:10.1126/science.205.4401.41, July 1979.
+            </reference_text>
+            <description>reference.DONAHUE1979</description>
+        </External_Reference>
+        <External_Reference>
+            <doi>10.1029/JA085iA13p07575</doi>
+            <reference_text>
+                Colin, L., The Pioneer Venus program, J. Geophys. Res., 85, No. A13, 7575-7598, 
+                doi:10.1029/JA085iA13p07575, Dec. 1980.
+            </reference_text>
+            <description>reference.COLIN1980</description>
+        </External_Reference>
+        <External_Reference>
+            <doi>10.1007/BF02186463</doi>
+            <reference_text>
+                Colin, L., Ed., and D. M., Ed. Hunten, Pioneer Venus experiment descriptions, 
+                Space Sci. Rev., 20, No. 4, 451-525, doi:10.1007/BF02186463, June 1977.
+            </reference_text>
+            <description>reference.COLINETAL1977</description>
+        </External_Reference>
+    </Reference_List>
+    
+    <Instrument_Host>
+        <name>PIONEER VENUS LARGE PROBE</name>
+        <type>Spacecraft</type>
+        <!--naif_host_id>PVO</naif_host_id-->
+
+        <description>
+ 
+    Instrument Host Overview
+    ========================
+ 
+      This spacecraft was the Large Probe (also called the Sounder Probe) 
+      portion of the Pioneer Venus Multiprobe mission. On this mission four 
+      instrumented atmospheric entry probes were carried by a spacecraft bus 
+      to the vicinity of Venus and released for descent through the atmosphere 
+      to the planetary surface. Two Small Probes entered on the nightside and 
+      a Small Probe and this Large Probe entered on the dayside of the planet. 
+      The spacecraft Bus entered the atmosphere and obtained atmospheric 
+      composition data until burnup. Investigations emphasized the study of the 
+      structure and composition of the atmosphere down to the surface, the nature 
+      and composition of the clouds, the radiation field and energy exchange in 
+      the lower atmosphere, and local information on the atmospheric circulation 
+      pattern. A sister mission, Pioneer Venus Orbiter, placed an orbiting 
+      spacecraft around Venus 5 days before the Probes entered the atmosphere. 
+      Simultaneous measurements by the Probes and Orbiter permitted relating 
+      specific local measurements to the general state of the planet and its 
+      environment as observed from orbit.
+ 
+    Platform Descriptions
+    =====================
+ 
+      The Large Probe comprised a spherical pressure vessel, a forward aeroshell 
+      heat shield, and an aft cover. The probe was 1.5 m in diameter and had a mass 
+      of 315 kg. The pressure vessel was built of three machined titanium parts: an 
+      aft hemisphere, a flat ring section, and a forward cap. Each section was flanged 
+      and bolted together and sealed with O-rings and graphoil gaskets. The interior 
+      of the pressure vessel was filled with 102 kPa of nitrogen. A pressure bottle 
+      held nitrogen to increase the internal pressure by 41 kPa. Two beryllium shelves 
+      held the instruments and spacecraft systems. The interior of the shell was lined 
+      with a 2.5 cm thick Kapton blanket. An antenna protruded from the top (aft) of 
+      the sphere. Two arms on the outside of the pressure vessel held a prism and an arm 
+      on the opposite side held a temperature sensor. There were 14 sealed penetrations 
+      in the pressure vessel: one for the antenna, four for electrical cables, two access 
+      hatches and seven for instruments. Power was provided by a 40 A-hr silver-zinc battery. 
+      Radio transmission at 2.3 GHz was powered by four 10-W amplifiers. The blunt cone-shaped 
+      aeroshell had an ablative carbon phenolic coating as a heat-shield. A pilot chute and 
+      mortar were mounted on the aeroshell and the main chute, held by the aft cover, was 
+      connected to three towers on the pressure vessel. The Large Probe carried a neutral 
+      mass spectrometer, a solar flux radiometer, an atmospheric structure experiment, a 
+      nephelometer, a cloud particle size spectrometer, a gas chromatograph, an infrared 
+      radiometer, and radio science experiments. The total cost of building and operating 
+      the probes was $83 million.
+      
+      The Large Probe, mounted on the Multiprobe Bus, was launched on the Pioneer Venus 2 
+      mission on 8 August 1978 at 07:33:00 UT from Cape Canaveral. There was one midcourse 
+      correction on 16 August 1978. The Large Probe was released from the Multiprobe Bus at 
+      02:37:13 UT on 16 November 1978 and entered the Venus atmosphere (200 km altitude) on 
+      9 December at 18:45:32 UT. Telemetry had been initiated 16 minutes earlier. The parachute 
+      was deployed at approximately 18:46:21 UT and the heat shield jettisoned at an altitude 
+      of 67 km. The parachute was jettisoned at 19:03:28 UT at an altitude of 47 km, and the 
+      probe impacted the surface (4.4 N, 304 E) at 19:39:53 UT, at which point transmissions 
+      ended.
+      
+        </description>
+    </Instrument_Host>
+</Product_Context>

--- a/data/pds4/context-pds4/instrument_host/spacecraft.pvmp.sp-day_2.0.xml
+++ b/data/pds4/context-pds4/instrument_host/spacecraft.pvmp.sp-day_2.0.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context xmlns="http://pds.nasa.gov/pds4/pds/v1"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+    
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:context:instrument_host:spacecraft.pvmp.sp-day</logical_identifier>
+        <version_id>2.0</version_id>
+        <title>PIONEER VENUS SMALL PROBE (DAY)</title>
+        <information_model_version>1.23.0.0</information_model_version>
+        <product_class>Product_Context</product_class>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2025-04-01</modification_date>
+                <version_id>2.0</version_id>
+                <description>Added reference for DLBI instrument</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2024-12-18</modification_date>
+                <version_id>1.1</version_id>
+                <description>Updated schema version. Description updated. Lynn Neakrase: removed naif_host_id as this spacecraft has no NAIF_ID</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2023-12-11</modification_date>
+                <version_id>1.0</version_id>
+                <description>Initial creation of the Multiprobe context products</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+
+    <Reference_List>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:investigation:mission.pioneer_venus</lid_reference>
+            <reference_type>instrument_host_to_investigation</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.sp-day.sas</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.sp-day.sn</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.sp-day.snfr</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+<!--        <Internal_Reference> -->
+<!--            <lid_reference>urn:nasa:pds:context:instrument:pvmp.sp-day.mpro</lid_reference> -->
+<!--            <reference_type>instrument_host_to_instrument</reference_type> -->
+<!--        </Internal_Reference> -->
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.sp-day.dlbi</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:target:planet.venus</lid_reference>
+            <reference_type>instrument_host_to_target</reference_type>
+        </Internal_Reference>
+        <External_Reference>
+            <doi>10.1126/science.205.4401.41</doi>
+            <reference_text>
+                Donahue, T. M., Pioneer Venus results: An overview, Science, 205, No. 4401, 41-44, 
+                doi:10.1126/science.205.4401.41, July 1979.
+            </reference_text>
+            <description>reference.DONAHUE1979</description>
+        </External_Reference>
+        <External_Reference>
+            <doi>10.1029/JA085iA13p07575</doi>
+            <reference_text>
+                Colin, L., The Pioneer Venus program, J. Geophys. Res., 85, No. A13, 7575-7598, 
+                doi:10.1029/JA085iA13p07575, Dec. 1980.
+            </reference_text>
+            <description>reference.COLIN1980</description>
+        </External_Reference>
+        <External_Reference>
+            <doi>10.1007/BF02186463</doi>
+            <reference_text>
+                Colin, L., Ed., and D. M., Ed. Hunten, Pioneer Venus experiment descriptions, 
+                Space Sci. Rev., 20, No. 4, 451-525, doi:10.1007/BF02186463, June 1977.
+            </reference_text>
+            <description>reference.COLINETAL1977</description>
+        </External_Reference>
+    </Reference_List>
+    
+    <Instrument_Host>
+        <name>PIONEER VENUS SMALL PROBE (DAY)</name>
+        <type>Spacecraft</type>
+        <!--naif_host_id>PVO</naif_host_id-->
+
+        <description>
+ 
+    Instrument Host Overview
+    ========================
+ 
+      This spacecraft was the third Small Probe of the Pioneer Venus 
+      Multiprobe mission. On this mission four instrumented atmospheric 
+      entry Probes were carried by a spacecraft Bus to the vicinity of 
+      Venus for descent through the atmosphere to the planetary surface. 
+      Two Small Probes entered on the nightside, and one Small Probe and 
+      one Large Probe entered on the dayside of the planet. The spacecraft 
+      Bus entered the atmosphere and obtained atmospheric composition data 
+      until burnup. Investigations emphasize the study of the structural 
+      composition and nature of the atmosphere down to the surface, and of 
+      the clouds, the radiation field and energy exchange in the lower 
+      atmosphere; and local information on the atmospheric circulation pattern. 
+      A sister mission, Pioneer Venus Orbiter, placed an orbiting spacecraft 
+      around Venus 5 days before the Probes entered the atmosphere. 
+      Simultaneous measurements by the Probes and the Orbiter permitted 
+      relating specific local measurements to the general state of the planet 
+      and its environment as observed from orbit.
+ 
+      The three small probes were identical and were designated the North Probe 
+      (1978-078E), the Night Probe (1978-078F), and the Day Probe (1978-078G). 
+      They were all mounted on the Multiprobe Bus (1978-078A) and were released 
+      on 20 November 1978. The probes were targeted for different entry points 
+      in the Venus atmosphere, all entered on 9 December 1978. The total cost 
+      of building and operating the Pioneer Venus probes was $83 million.
+ 
+
+ 
+ 
+    Platform Descriptions
+    =====================
+ 
+      The probe consisted of a spherical pressure vessel surrounded by a forward 
+      conical heat shield and an afterbody. The probes had a mass of 90 kg and a 
+      diameter of 0.8 m. The pressure vessel held all the scientific instruments 
+      and spacecraft systems. It was made of two precisely machined flanged titanium 
+      hemispheres joined by bolts with seals between. The seals comprised O-rings and 
+      graphoil flat gaskets. The vessel walls were lined on the inside with Kapton 
+      blankets and the interior was filled with 102 kPa of Xenon. The instruments were 
+      mounted on two beryllium shelves to absorb heat. A small hemispherical antenna 
+      protruded from the top of the pressure vessel. The pressure vessel had 7 openings, 
+      one for the antenna, three for electrical cables, two for scientific instruments, 
+      and one for an access hatch. There were also special diamond and sapphire windows. 
+      The probe did not have any thrusters, once released it was on a ballistic trajectory. 
+      The aeroshell was a 45 degree blunt cone made of titanium which used a bonded 
+      carbon phenolic ablative coating as a heat shield. The aeroshell was permanently 
+      attached to the pressure vessel, as was the fiberglass honeycomb afterbody. The 
+      small probes did not have parachutes. The small probe carried an atmospheric 
+      structure experiment, a nephelometer, a net-flux radiometer, and radio science 
+      experiments.
+ 
+      The Day Probe was released from the Multiprobe Bus at 13:06:29 UT on 20 November 1978. 
+      (All times are given in spacecraft time, Earth received time was approximately 3 minutes 
+      later.) It was targeted for the dayside at midsouthern latitudes and reached Venus on 
+      9 December 1978. The probe initiated telemetry at 18:35:27 UT and entered the atmosphere 
+      (200 km altitude) at 18:52:18 UT. After a 56 minute descent, the probe touched down on the 
+      surface (31.3 S, 317 E) at 19:47:59 UT. The probe continued to transmit for another 
+      67 minutes, 37 seconds after landing.
+      
+        </description>
+    </Instrument_Host>
+</Product_Context>

--- a/data/pds4/context-pds4/instrument_host/spacecraft.pvmp.sp-night_2.0.xml
+++ b/data/pds4/context-pds4/instrument_host/spacecraft.pvmp.sp-night_2.0.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context xmlns="http://pds.nasa.gov/pds4/pds/v1"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+    
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:context:instrument_host:spacecraft.pvmp.sp-night</logical_identifier>
+        <version_id>2.0</version_id>
+        <title>PIONEER VENUS SMALL PROBE (NIGHT)</title>
+        <information_model_version>1.23.0.0</information_model_version>
+        <product_class>Product_Context</product_class>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2025-04-01</modification_date>
+                <version_id>2.0</version_id>
+                <description>Added reference for DLBI instrument</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2024-12-18</modification_date>
+                <version_id>1.1</version_id>
+                <description>Updated schema version. Description updated. Removed naif_host_id at Lynn Neakrase's request</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2023-12-11</modification_date>
+                <version_id>1.0</version_id>
+                <description>Initial creation of the Multiprobe context products</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+
+    <Reference_List>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:investigation:mission.pioneer_venus</lid_reference>
+            <reference_type>instrument_host_to_investigation</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.sp-night.sas</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.sp-night.sn</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.sp-night.snfr</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+<!--    <Internal_Reference> -->
+<!--            <lid_reference>urn:nasa:pds:context:instrument:pvmp.sp-night.mpro</lid_reference> -->
+<!--            <reference_type>instrument_host_to_instrument</reference_type> -->
+<!--        </Internal_Reference> -->
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.sp-night.dlbi</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:target:planet.venus</lid_reference>
+            <reference_type>instrument_host_to_target</reference_type>
+        </Internal_Reference>
+        <External_Reference>
+            <doi>10.1126/science.205.4401.41</doi>
+            <reference_text>
+                Donahue, T. M., Pioneer Venus results: An overview, Science, 205, No. 4401, 41-44, 
+                doi:10.1126/science.205.4401.41, July 1979.
+            </reference_text>
+            <description>reference.DONAHUE1979</description>
+        </External_Reference>
+        <External_Reference>
+            <doi>10.1029/JA085iA13p07575</doi>
+            <reference_text>
+                Colin, L., The Pioneer Venus program, J. Geophys. Res., 85, No. A13, 7575-7598, 
+                doi:10.1029/JA085iA13p07575, Dec. 1980.
+            </reference_text>
+            <description>reference.COLIN1980</description>
+        </External_Reference>
+        <External_Reference>
+            <doi>10.1007/BF02186463</doi>
+            <reference_text>
+                Colin, L., Ed., and D. M., Ed. Hunten, Pioneer Venus experiment descriptions, 
+                Space Sci. Rev., 20, No. 4, 451-525, doi:10.1007/BF02186463, June 1977.
+            </reference_text>
+            <description>reference.COLINETAL1977</description>
+        </External_Reference>
+    </Reference_List>
+    
+    <Instrument_Host>
+        <name>PIONEER VENUS SMALL PROBE (NIGHT)</name>
+        <type>Spacecraft</type>
+        <!--naif_host_id>PVO</naif_host_id-->
+
+        <description>
+ 
+    Instrument Host Overview
+    ========================
+ 
+      This spacecraft was the second Small Probe of the Pioneer Venus 
+      Multiprobe mission. On this mission four instrumented atmospheric 
+      entry probes were carried by a spacecraft Bus to the vicinity of 
+      Venus for descent through the atmosphere to the planetary surface. 
+      Two Small Probes entered on the nightside, and one Small Probe and 
+      one Large Probe entered on the dayside of the planet. The spacecraft 
+      Bus entered the atmosphere and obtained atmospheric composition data 
+      until burnup. Investigations emphasized the study of the structure 
+      composition and nature of the atmosphere down to the surface, and of 
+      the clouds, the radiation field and energy exchange in the lower 
+      atmosphere, and local information on the atmospheric circulation 
+      pattern. A sister mission, Pioneer Venus Orbiter, placed an orbiting 
+      spacecraft around Venus 5 days before the Probes entered the atmosphere. 
+      Simultaneous measurements by the Probes and Orbiter permitted relating 
+      specific local measurements to the general state of the planet and its 
+      environment as observed from orbit.
+ 
+      The three small probes were identical and were designated the North Probe 
+      (1978-078E), the Night Probe (1978-078F), and the Day Probe (1978-078G). 
+      They were all mounted on the Multiprobe Bus (1978-078A) and were released 
+      on 20 November 1978. The probes were targeted for different entry points 
+      in the Venus atmosphere, all entered on 9 December 1978. The total cost of 
+      building and operating the Pioneer Venus probes was $83 million.
+ 
+
+
+
+    Platform Descriptions
+    =====================
+ 
+      The probe consisted of a spherical pressure vessel surrounded by a forward 
+      conical heat shield and an afterbody. The probes had a mass of 90 kg and a 
+      diameter of 0.8 m. The pressure vessel held all the scientific instruments 
+      and spacecraft systems. It was made of two precisely machined flanged titanium 
+      hemispheres joined by bolts with seals between. The seals comprised O-rings 
+      and graphoil flat gaskets. The vessel walls were lined on the inside with Kapton 
+      blankets and the interior was filled with 102 kPa of Xenon. The instruments were 
+      mounted on two beryllium shelves to absorb heat. A small hemispherical antenna 
+      protruded from the top of the pressure vessel. The pressure vessel had 7 openings, 
+      one for the antenna, three for electrical cables, two for scientific instruments, 
+      and one for an access hatch. There were also special diamond and sapphire windows. 
+      The probe did not have any thrusters, once released it was on a ballistic trajectory. 
+      The aeroshell was a 45 degree blunt cone made of titanium which used a bonded carbon 
+      phenolic ablative coating as a heat shield. The aeroshell was permanently attached 
+      to the pressure vessel, as was the fiberglass honeycomb afterbody. The small probes 
+      did not have parachutes. The small probe carried an atmospheric structure experiment, 
+      a nephelometer, a net-flux radiometer, and radio science experiments.
+      
+      The Night Probe was released from the Multiprobe Bus at 13:06:29 on 20 November 1978. 
+      (All times are given in spacecraft time, Earth received time was approximately 3 minutes 
+      later.) It was targeted for the nightside at midsouthern latitudes and reached Venus on 
+      9 December 1978. The probe initiated telemetry at 18:39:08 UT and entered the atmosphere 
+      (200 km altitude) at 18:56:13 UT. After a 56 minute descent, the probe touched down on 
+      the surface (28.7 S, 56.7 E) at 19:52:05 UT. The probe transmitted for 2 more seconds 
+      after impact.
+      
+        </description>
+    </Instrument_Host>
+</Product_Context>

--- a/data/pds4/context-pds4/instrument_host/spacecraft.pvmp.sp-north_2.0.xml
+++ b/data/pds4/context-pds4/instrument_host/spacecraft.pvmp.sp-north_2.0.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context xmlns="http://pds.nasa.gov/pds4/pds/v1"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+    
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:context:instrument_host:spacecraft.pvmp.sp-north</logical_identifier>
+        <version_id>2.0</version_id>
+        <title>PIONEER VENUS SMALL PROBE (NORTH)</title>
+        <information_model_version>1.23.0.0</information_model_version>
+        <product_class>Product_Context</product_class>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2025-04-01</modification_date>
+                <version_id>2.0</version_id>
+                <description>Added reference for DLBI instrument</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2023-12-11</modification_date>
+                <version_id>1.0</version_id>
+                <description>Initial creation of the Multiprobe context products</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+
+    <Reference_List>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:investigation:mission.pioneer_venus</lid_reference>
+            <reference_type>instrument_host_to_investigation</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.sp-north.sas</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.sp-north.sn</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.sp-north.snfr</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+<!--    <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.sp-north.mpro</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>               -->
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:pvmp.sp-north.dlbi</lid_reference>
+            <reference_type>instrument_host_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:target:planet.venus</lid_reference>
+            <reference_type>instrument_host_to_target</reference_type>
+        </Internal_Reference>
+        <External_Reference>
+            <doi>10.1126/science.205.4401.41</doi>
+            <reference_text>
+                Donahue, T. M., Pioneer Venus results: An overview, Science, 205, No. 4401, 41-44, 
+                doi:10.1126/science.205.4401.41, July 1979.
+            </reference_text>
+            <description>reference.DONAHUE1979</description>
+        </External_Reference>
+        <External_Reference>
+            <doi>10.1029/JA085iA13p07575</doi>
+            <reference_text>
+                Colin, L., The Pioneer Venus program, J. Geophys. Res., 85, No. A13, 7575-7598, 
+                doi:10.1029/JA085iA13p07575, Dec. 1980.
+            </reference_text>
+            <description>reference.COLIN1980</description>
+        </External_Reference>
+        <External_Reference>
+            <doi>10.1007/BF02186463</doi>
+            <reference_text>
+                Colin, L., Ed., and D. M., Ed. Hunten, Pioneer Venus experiment descriptions, 
+                Space Sci. Rev., 20, No. 4, 451-525, doi:10.1007/BF02186463, June 1977.
+            </reference_text>
+            <description>reference.COLINETAL1977</description>
+        </External_Reference>
+    </Reference_List>
+    
+    <Instrument_Host>
+        <name>PIONEER VENUS SMALL PROBE (NORTH)</name>
+        <type>Spacecraft</type>
+        <!--naif_host_id>PVO</naif_host_id-->
+
+        <description>
+ 
+    Instrument Host Overview
+    ========================
+ 
+      This spacecraft was the first Small Probe of the Pioneer Venus 
+      Multiprobe mission. On this mission four instrumented atmospheric 
+      entry probes were carried by a spacecraft Bus to the vicinity of 
+      Venus for descent through the atmosphere to the planetary surface. 
+      Two Small Probes entered on the nightside, and one Small Probe and 
+      one Large Probe entered on the dayside of the planet. The spacecraft 
+      Bus entered the atmosphere and obtained atmospheric composition data 
+      until burnup. Investigations emphasized the study of the structure 
+      composition and nature of the atmosphere down to the surface, and of 
+      the clouds, the radiation field and energy exchange in the lower 
+      atmosphere, and local information on the atmospheric circulation pattern. 
+      A sister mission, Pioneer Venus Orbiter, placed an orbiting spacecraft 
+      around Venus 5 days before the Probes entered the atmosphere. 
+      Simultaneous measurements by the Probes and Orbiter permitted relating 
+      specific local measurements to the general state of the planet and its 
+      environment as observed from orbit.
+ 
+      The three small probes were identical and were designated the North Probe 
+      (1978-078E), the Night Probe (1978-078F), and the Day Probe (1978-078G). 
+      They were all mounted on the Multiprobe Bus (1978-078A) and were released 
+      on 20 November 1978. The probes were targeted for different entry points in 
+      the Venus atmosphere, all entered on 9 December 1978. The total cost of 
+      building and operating the Pioneer Venus probes was $83 million.
+
+
+
+ 
+    Platform Descriptions
+    =====================
+ 
+      The probe consisted of a spherical pressure vessel surrounded by a forward 
+      conical heat shield and an afterbody. The probes had a mass of 90 kg and a 
+      diameter of 0.8 m. The pressure vessel held all the scientific instruments 
+      and spacecraft systems. It was made of two precisely machined flanged titanium 
+      hemispheres joined by bolts with seals between. The seals comprised O-rings 
+      and graphoil flat gaskets. The vessel walls were lined on the inside with 
+      Kapton blankets and the interior was filled with 102 kPa of Xenon. The instruments 
+      were mounted on two beryllium shelves to absorb heat. A small hemispherical 
+      antenna protruded from the top of the pressure vessel. The pressure vessel had 
+      7 openings, one for the antenna, three for electrical cables, two for scientific 
+      instruments, and one for an access hatch. There were also special diamond and 
+      sapphire windows. The probe did not have any thrusters, once released it was on 
+      a ballistic trajectory. The aeroshell was a 45 degree blunt cone made of titanium 
+      which used a bonded carbon phenolic ablative coating as a heat shield. The aeroshell 
+      was permanently attached to the pressure vessel, as was the fiberglass honeycomb 
+      afterbody. The small probes did not have parachutes. The small probe carried an 
+      atmospheric structure experiment, a nephelometer, a net-flux radiometer, and radio 
+      science experiments.
+      
+      The North Probe was released from the Multiprobe Bus at 13:06:29 UT on 20 November 1978. 
+      (All times are given in spacecraft time, Earth received time was approximately 3 minutes 
+      later.) It was targeted for the nightside at high northern latitudes and reached Venus on 
+      9 December 1978. The probe initiated telemetry at 18:32:55 UT and entered the atmosphere 
+      (200 km altitude) at 18:49:40 UT. After a 53 minute descent, the probe touched down on the 
+      surface (59.3 N, 4.8 E) at 19:42:40 UT. Signals ended at this time.  
+        
+        </description>
+    </Instrument_Host>
+</Product_Context>

--- a/data/pds4/context-pds4/investigation/field_campaign.dd_nnss-nv_2019_1.2.xml
+++ b/data/pds4/context-pds4/investigation/field_campaign.dd_nnss-nv_2019_1.2.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context xmlns="http://pds.nasa.gov/pds4/pds/v1"
+ xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:context:investigation:field_campaign.dd_nnss-nv_2019</logical_identifier>
+        <version_id>1.2</version_id>
+        <title>Dust Devil Field Campaign, Nevada National Security Site (NNSS), Nevada, 2019</title>
+        <information_model_version>1.23.0.0</information_model_version>
+        <product_class>Product_Context</product_class>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2025-05-06</modification_date>
+                <version_id>1.2</version_id>
+                <description>Additional instrument added</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2025-04-17</modification_date>
+                <version_id>1.1</version_id>
+                <description>Updated schema version.</description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2023-11-27</modification_date>
+                <version_id>1.0</version_id>
+                <description>Initial setup for this investigation.</description>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>  
+    <Reference_List>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:no-host.hyperion-ifs5000</lid_reference>
+            <reference_type>investigation_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:instrument:no-host.hyperion-ifs3000</lid_reference>
+            <reference_type>investigation_to_instrument</reference_type>
+        </Internal_Reference>
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:target:planet.earth</lid_reference>
+            <reference_type>investigation_to_target</reference_type>
+        </Internal_Reference>
+        <External_Reference>
+            <doi>10.1175/JTECH-D-23-0037.1</doi>
+            <reference_text>Berg, E.M., L.J. Utrecho, S. Krishnamoorthy, E.A. Silber, A. Sparks, and D.C. Bowman (2024) An accurate and Automated Convective Vortex Detection Method for Long-Duration Infrasound Microbarometer Data, Journal of Atmospheric and Oceanic Technology, 41, 341-354</reference_text>
+            <description>Citation of the official published paper.</description>
+        </External_Reference>
+    </Reference_List>
+    <Investigation>
+        <name>Dust Devil Field Campaign, Nevada National Security Site (NNSS), Nevada, 2019</name>
+        <type>Field Campaign</type>
+        <start_date>2012</start_date>  
+        <stop_date>2019</stop_date>
+        <description> 
+        A dust devil field campaign at the nuclear test stie at the Nevada National Security Site, Nevada conducted over 2019-2023 by Danny Bowman, et al. The work catalogged 
+        terrestrial dust devils to serve as planetary analogs to dust devils on Mars. The remote recording stations, consisting of Hyperion IFS-5000 Series Seismically 
+        Decoupled Infrasound Sensors (microbarometers), used in this study provided pressure and temperature data for dust devil encounters in the desert. 
+        </description>
+    </Investigation>
+</Product_Context>

--- a/data/pds4/context-pds4/investigation/observing_campaign.atlas.xml
+++ b/data/pds4/context-pds4/investigation/observing_campaign.atlas.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+    schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<Product_Context xmlns="http://pds.nasa.gov/pds4/pds/v1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  
+    <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:investigation:observing_campaign.atlas</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>Asteroid Terrestrial-impact Last Alert System (ATLAS)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2025-05-08</modification_date>
+        <version_id>1.0</version_id>
+        <description>Creation (B. Hirsch)</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  
+  <Reference_List>
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:facility:observatory.atlas-chl</lid_reference>
+      <reference_type>investigation_to_facility</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:facility:observatory.atlas-hko</lid_reference>
+      <reference_type>investigation_to_facility</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:facility:observatory.atlas-mlo</lid_reference>
+      <reference_type>investigation_to_facility</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:facility:observatory.atlas-cpt</lid_reference>
+      <reference_type>investigation_to_facility</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:telescope:atlas-chl.0m5</lid_reference>
+      <reference_type>investigation_to_telescope</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:telescope:atlas-hko.0m5</lid_reference>
+      <reference_type>investigation_to_telescope</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:telescope:atlas-mlo.0m5</lid_reference>
+      <reference_type>investigation_to_telescope</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:telescope:atlas-cpt.0m5</lid_reference>
+      <reference_type>investigation_to_telescope</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:instrument:atlas-chl.0m5.sta1600</lid_reference>
+      <reference_type>investigation_to_instrument</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:instrument:atlas-hko.0m5.sta1600</lid_reference>
+      <reference_type>investigation_to_instrument</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:instrument:atlas-mlo.0m5.sta1600</lid_reference>
+      <reference_type>investigation_to_instrument</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:instrument:atlas-cpt.0m5.sta1600</lid_reference>
+      <reference_type>investigation_to_instrument</reference_type>
+    </Internal_Reference>
+
+    <External_Reference>
+      <doi>10.1088/1538-3873/aabadf</doi>
+      <reference_text>ATLAS: A High-cadence All-sky Survey System. Tonry, J., et al. Publ. Astr. Soc. Pacific, 139, 478 (2018)</reference_text>
+    </External_Reference>
+  </Reference_List>
+
+  <Investigation>
+    <name>Asteroid Terrestrial-impact Last Alert System (ATLAS)</name>
+    <type>Observing Campaign</type>
+    <start_date>2015</start_date>
+    <stop_date xsi:nil="true" nilReason="inapplicable"/>
+    <description>
+      ATLAS is an asteroid impact early warning system developed by the University of
+      Hawaii and funded by NASA. It consists of four telescopes (Hawaii ×2, Chile, South
+      Africa), which automatically scan the whole sky several times every night looking
+      for moving objects.
+    </description>
+  </Investigation>
+</Product_Context>

--- a/data/pds4/context-pds4/investigation/other_investigation.media.dsn_1.1.xml
+++ b/data/pds4/context-pds4/investigation/other_investigation.media.dsn_1.1.xml
@@ -1,23 +1,29 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1M00.sch"
-schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<Product_Context xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:pds="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1M00.xsd">
-  <Identification_Area>
-    <logical_identifier>urn:nasa:pds:context:investigation:other_investigation.media.dsn</logical_identifier>
-    <version_id>1.1</version_id>
-    <title>DSN Media Calibration</title>
-    <information_model_version>1.22.0.0</information_model_version>
-    <product_class>Product_Context</product_class>
-    <Modification_History>
-      <Modification_Detail>
-        <modification_date>2024-12-29</modification_date>
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+ <Product_Context xmlns="http://pds.nasa.gov/pds4/pds/v1"
+ xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+
+    <Identification_Area>
+        <logical_identifier>urn:nasa:pds:context:investigation:other_investigation.media.dsn</logical_identifier>
         <version_id>1.1</version_id>
-        <description>Updated schema version. Description updated.</description>
-      </Modification_Detail>
-      <Modification_Detail>
-        <modification_date>2020-07-30</modification_date>
-        <version_id>1.0</version_id>
-        <description>
+        <title>DSN Media Calibration</title>
+        <information_model_version>1.23.0.0</information_model_version>
+        <product_class>Product_Context</product_class>
+        
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>2025-03-30</modification_date>
+                <version_id>1.1</version_id>
+                <description>
+                    Simplified Identification_Area.title (now same as Investigation.name).
+                    Updated to IM v1.23.0.0.
+                </description>
+            </Modification_Detail>
+            <Modification_Detail>
+                <modification_date>2020-07-30</modification_date>
+                <version_id>1.0</version_id>
+                <description>
                     The DSN Media Calibration investigation is the set of observations and analyses
                     used by the NASA Deep Space Network (DSN) to develop calibrations for the effects
                     of the ionosphere, troposphere, and local weather on propagation of radio signals
@@ -25,18 +31,21 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     and can change the apparent range to and velocity of spacecraft being tracked by 
                     the DSN.
                 </description>
-      </Modification_Detail>
-    </Modification_History>
-  </Identification_Area>
-  <Reference_List>
-    <Internal_Reference>
-      <lid_reference>urn:nasa:pds:context:facility:observatory.dsn</lid_reference>
-      <reference_type>investigation_to_facility</reference_type>
-    </Internal_Reference>
-    <Internal_Reference>
-      <lid_reference>urn:nasa:pds:radiosci.documentation:dsn.810-005</lid_reference>
-      <reference_type>investigation_to_document</reference_type>
-      <comment>
+            </Modification_Detail>
+        </Modification_History>
+    </Identification_Area>
+
+    <Reference_List>
+
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:context:facility:observatory.dsn</lid_reference>
+            <reference_type>investigation_to_facility</reference_type>
+        </Internal_Reference>
+
+        <Internal_Reference>
+            <lid_reference>urn:nasa:pds:radiosci.documentation:dsn.810-005</lid_reference>
+            <reference_type>investigation_to_document</reference_type>
+            <comment>
                 This is the DSN Telecommunications Link Design Handbook. The reference is 
                 to a PDS Collection. Each member product in the Collection comprises several 
                 modules -- sometimes separate files, sometimes wrapped together into a single
@@ -46,15 +55,16 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 that were current as of the publication date.  Module 105 (Atmospherc and 
                 Environmental effects) may be of special interest here.
             </comment>
-    </Internal_Reference>
-    <External_Reference>
-      <reference_text>
+        </Internal_Reference>
+        
+        <External_Reference>
+            <reference_text>
                 Asmar, S. W., J. W. Armstrong, L. Iess, and P. Tortora, Spacecraft 
                 Doppler Tracking: Noise Budget and Accuracy Achievable in Precision Radio 
                 Science Observations, Radio Science, 40, RS2001, doi:10.1029/2004RS003101,
                 2005.
             </reference_text>
-      <description>
+            <description>
                 This paper discusses noise in Doppler tracking of deep space probes and 
                 provides a detailed noise model for Doppler radio science experiments. 
                 Current technology allows velocity measurements to better than 1 micron 
@@ -63,13 +73,23 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 planning are considered, and the authors discuss the prospects for 
                 significant sensitivity improvements.
             </description>
-    </External_Reference>
-  </Reference_List>
-  <Investigation>
-    <name>DSN Media Calibration</name>
-    <type>Other Investigation</type>
-    <start_date>1950-01-01</start_date>
-    <stop_date>2099-12-31</stop_date>
-    <description>The Deep Space Network (DSN) Media Calibration investigation involves observations and analyses by the NASA Deep Space Network to calibrate the impacts of the ionosphere, troposphere, and local weather on radio signal propagation between DSN antennas and spacecraft. These effects, although small, are measurable and can alter the apparent range and velocity of tracked spacecraft.</description>
-  </Investigation>
-</Product_Context>
+        </External_Reference>
+       
+    </Reference_List>
+     
+     <Investigation>
+         <name>DSN Media Calibration</name>
+         <type>Other Investigation</type>
+         <start_date>1950-01-01</start_date>
+         <stop_date>2099-12-31</stop_date>
+         <description>
+             The DSN Media Calibration investigation is the set of observations and analyses
+             used by the NASA Deep Space Network (DSN) to develop calibrations for the effects
+             of the ionosphere, troposphere, and local weather on propagation of radio signals
+             between DSN antennas and spacecraft.  Although small, these effects are measurable
+             and can change the apparent range to and velocity of spacecraft being tracked by 
+             the DSN.
+         </description>
+     </Investigation>
+     
+ </Product_Context>

--- a/data/pds4/context-pds4/target/comet.141p_machholz_2_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.141p_machholz_2_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.141p_machholz_2</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>141P/Machholz 2</title> <!-- e.g. C/2004 Q2 (Machholz) or 65P/Gunn -->
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1003394</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>141P/Machholz 2</name> <!-- e.g. C/2004 Q2 (Machholz) or 65P/Gunn -->
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.96p_machholz_1_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.96p_machholz_1_1.0.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.96p_machholz_1</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>96P/Machholz 1</title> <!-- e.g. C/2004 Q2 (Machholz) or 65P/Gunn -->
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>96P/1986 J2</alternate_title></Alias>
+      <Alias><alternate_title>NAIF ID 1000061</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>96P/Machholz 1</name> <!-- e.g. C/2004 Q2 (Machholz) or 65P/Gunn -->
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c1996_q1_tabur_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c1996_q1_tabur_1.0.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c1996_q1_tabur</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/1996 Q1 (Tabur)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>D/1996 Q1 (Tabur)</alternate_title></Alias>  <!-- from SBN. IAU retains C/ post-fadeout -->
+      <Alias><alternate_title>NAIF ID 1000208</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-07</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node after consulting UMD and Gareth Williams of IAU</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/1996 Q1 (Tabur)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c1997_o1_tilbrook_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c1997_o1_tilbrook_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c1997_o1_tilbrook</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/1997 O1 (Tilbrook)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1000210</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/1997 O1 (Tilbrook)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c1998_u5_linear_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c1998_u5_linear_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c1998_u5_linear</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/1998 U5 (LINEAR)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1000235</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/1998 U5 (LINEAR)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c1999_j3_linear_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c1999_j3_linear_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c1999_j3_linear</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/1999 J3 (LINEAR)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1000268</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/1999 J3 (LINEAR)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c1999_n2_lynn_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c1999_n2_lynn_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c1999_n2_lynn</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/1999 N2 (Lynn)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1000270</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/1999 N2 (Lynn)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c1999_s4_linear_1.2.xml
+++ b/data/pds4/context-pds4/target/comet.c1999_s4_linear_1.2.xml
@@ -1,35 +1,31 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1M00.sch"
-schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<Product_Context xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:pds="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1M00.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
   <Identification_Area>
     <logical_identifier>urn:nasa:pds:context:target:comet.c1999_s4_linear</logical_identifier>
     <version_id>1.2</version_id>
     <title>C/1999 S4 (LINEAR)</title>
-    <information_model_version>1.22.0.0</information_model_version>
+    <information_model_version>1.23.0.0</information_model_version>
     <product_class>Product_Context</product_class>
     <Alias_List>
-      <Alias>
-        <alternate_title>C/1999 S4 LINEAR</alternate_title>
-      </Alias>
-      <Alias>
-        <alternate_title>LINEAR (C/1999 S4)</alternate_title>
-      </Alias>
-      <Alias>
-        <alternate_title>C/1999 S4</alternate_title>
-      </Alias>
-      <Alias>
-        <alternate_title>LINEAR</alternate_title>
-      </Alias>
-      <Alias>
-        <alternate_title>NAIF ID 1000273</alternate_title>
-      </Alias>
+      <Alias><alternate_title>D/1999 S4 (LINEAR)</alternate_title></Alias>  <!-- from SBN. IAU retains C/ post-disintegration -->
+      <Alias><alternate_title>C/1999 S4 LINEAR</alternate_title></Alias>
+      <Alias><alternate_title>LINEAR (C/1999 S4)</alternate_title></Alias>
+      <Alias><alternate_title>C/1999 S4</alternate_title></Alias>
+      <Alias><alternate_title>LINEAR</alternate_title></Alias>
+      <Alias><alternate_title>NAIF ID 1000273</alternate_title></Alias>
     </Alias_List>
     <Modification_History>
       <Modification_Detail>
-        <modification_date>2025-04-24</modification_date>
+        <modification_date>2023-06-07</modification_date>
         <version_id>1.2</version_id>
-        <description>Updated schema version.</description>
+        <description>From PDS Engineering Node after consulting UMD and Gareth Williams of IAU. Added alias D/1999 S4</description>
       </Modification_Detail>
       <Modification_Detail>
         <modification_date>2018-11-18</modification_date>

--- a/data/pds4/context-pds4/target/comet.c2001_a2_linear_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2001_a2_linear_1.0.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2001_a2_linear</logical_identifier>
+    <!-- ssd dropped C2001 A2 after disintegration but does have "C/2001 A2-A" and -B -->
+    <version_id>1.0</version_id>
+    <title>C/2001 A2 (LINEAR)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1000327</alternate_title></Alias>  <!-- from Alan Chamberlain -->
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-07</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node after consulting UMD and Alan Chamberlain of JPL's SSD</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2001 A2 (LINEAR)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2001_og108_loneos_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2001_og108_loneos_1.0.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2001_og108_loneos</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2001 OG108 (LONEOS)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>P/2001 OG108 (LONEOS 5)</alternate_title></Alias>  <!-- from SBN. Garth Williams: The use of post-name numerals was abandoned in the revamp of the comet designation system that occurred at the start of 1995 -->
+      <Alias><alternate_title>NAIF ID 1000373</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-07</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node after consulting UMD and Gareth Williams of IAU</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2001 OG108 (LONEOS)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2002_g3_soho_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2002_g3_soho_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2002_g3_soho</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2002 G3 (SOHO)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1001785</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2002 G3 (SOHO)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2002_o4_hoenig_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2002_o4_hoenig_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2002_o4_hoenig</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2002 O4 (Hoenig)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1000398</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2002 O4 (Hoenig)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2002_v1_neat_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2002_v1_neat_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2002_v1_neat</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2002 V1 (NEAT)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1000419</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2002 V1 (NEAT)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2002_x5_kudo-fujikawa_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2002_x5_kudo-fujikawa_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2002_x5_kudo-fujikawa</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2002 X5 (Kudo-Fujikawa)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1000423</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2002 X5 (Kudo-Fujikawa)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2002_y1_juels-hovorcem_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2002_y1_juels-hovorcem_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2002_y1_juels-hovorcem</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2002 Y1 (Juels-Holvorcem)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1000424</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2002 Y1 (Juels-Holvorcem)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2006_m4_swan_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2006_m4_swan_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2006_m4_swan</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2006 M4 (SWAN)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1002407</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2006 M4 (SWAN)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2007_f1_loneos_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2007_f1_loneos_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2007_f1_loneos</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2007 F1 (LONEOS)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1002450</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2007 F1 (LONEOS)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2009_r1_mcnaught_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2009_r1_mcnaught_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2009_r1_mcnaught</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2009 R1 (McNaught)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1003036</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2009 R1 (McNaught)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2011_l4_panstarrs_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2011_l4_panstarrs_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2011_l4_panstarrs</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2011 L4 (PANSTARRS)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1003133</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2011 L4 (PANSTARRS)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2012_e2_swan_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2012_e2_swan_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2012_e2_swan</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2012 E2 (SWAN)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1003178</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2012 E2 (SWAN)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2012_f6_lemmon_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2012_f6_lemmon_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2012_f6_lemmon</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2012 F6 (Lemmon)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1003183</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2012 F6 (Lemmon)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2012_k1_panstarrs_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2012_k1_panstarrs_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2012_k1_panstarrs</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2012 K1 (PANSTARRS)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1003190</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2012 K1 (PANSTARRS)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2013_r1_lovejoy_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2013_r1_lovejoy_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2013_r1_lovejoy</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2013 R1 (Lovejoy)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1003274</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2013 R1 (Lovejoy)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2013_us10_catalina_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2013_us10_catalina_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2013_us10_catalina</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2013 US10 (Catalina)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1003283</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2013 US10 (Catalina)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2013_v5_oukaimeden_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2013_v5_oukaimeden_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2013_v5_oukaimeden</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2013 V5 (Oukaimeden)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1003288</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2013 V5 (Oukaimeden)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2013_x1_panstarrs_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2013_x1_panstarrs_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2013_x1_panstarrs</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2013 X1 (PANSTARRS)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1003291</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2013 X1 (PANSTARRS)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2014_e2_jacques_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2014_e2_jacques_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2014_e2_jacques</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2014 E2 (Jacques)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1003306</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2014 E2 (Jacques)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2014_q1_panstarrs_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2014_q1_panstarrs_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2014_q1_panstarrs</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2014 Q1 (PANSTARRS)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1003330</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2014 Q1 (PANSTARRS)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/target/comet.c2015_g2_master_1.0.xml
+++ b/data/pds4/context-pds4/target/comet.c2015_g2_master_1.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.sch"
+  schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Context
+  xmlns="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1N00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:context:target:comet.c2015_g2_master</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>C/2015 G2 (MASTER)</title>
+    <information_model_version>1.23.0.0</information_model_version>
+    <product_class>Product_Context</product_class>
+    <Alias_List>
+      <Alias><alternate_title>NAIF ID 1003383</alternate_title></Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2023-06-05</modification_date>
+        <version_id>1.0</version_id>
+        <description>From PDS Engineering Node</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Target>
+    <name>C/2015 G2 (MASTER)</name>
+    <type>Comet</type>
+    <description>none</description>
+  </Target>
+</Product_Context>

--- a/data/pds4/context-pds4/telescope/atlas-chl.0m5_1.0.xml
+++ b/data/pds4/context-pds4/telescope/atlas-chl.0m5_1.0.xml
@@ -30,6 +30,11 @@
 
   <Reference_List>
     <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:observing_campaign.atlas</lid_reference>
+      <reference_type>telescope_to_investigation</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
       <lid_reference>urn:nasa:pds:context:facility:observatory.atlas-chl</lid_reference>
       <reference_type>telescope_to_facility</reference_type>
     </Internal_Reference>

--- a/data/pds4/context-pds4/telescope/atlas-cpt.0m5_1.0.xml
+++ b/data/pds4/context-pds4/telescope/atlas-cpt.0m5_1.0.xml
@@ -30,6 +30,11 @@
 
   <Reference_List>
     <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:observing_campaign.atlas</lid_reference>
+      <reference_type>telescope_to_investigation</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
       <lid_reference>urn:nasa:pds:context:facility:observatory.atlas-cpt</lid_reference>
       <reference_type>telescope_to_facility</reference_type>
     </Internal_Reference>

--- a/data/pds4/context-pds4/telescope/atlas-hko.0m5_1.0.xml
+++ b/data/pds4/context-pds4/telescope/atlas-hko.0m5_1.0.xml
@@ -30,6 +30,11 @@
 
   <Reference_List>
     <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:observing_campaign.atlas</lid_reference>
+      <reference_type>telescope_to_investigation</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
       <lid_reference>urn:nasa:pds:context:facility:observatory.atlas-hko</lid_reference>
       <reference_type>telescope_to_facility</reference_type>
     </Internal_Reference>

--- a/data/pds4/context-pds4/telescope/atlas-mlo.0m5_1.0.xml
+++ b/data/pds4/context-pds4/telescope/atlas-mlo.0m5_1.0.xml
@@ -30,6 +30,11 @@
 
   <Reference_List>
     <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:investigation:observing_campaign.atlas</lid_reference>
+      <reference_type>telescope_to_investigation</reference_type>
+    </Internal_Reference>
+
+    <Internal_Reference>
       <lid_reference>urn:nasa:pds:context:facility:observatory.atlas-mlo</lid_reference>
       <reference_type>telescope_to_facility</reference_type>
     </Internal_Reference>

--- a/data/pds4/context-pds4/telescope/canberra.dss42_34m_1.1.xml
+++ b/data/pds4/context-pds4/telescope/canberra.dss42_34m_1.1.xml
@@ -5,7 +5,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
   <Identification_Area>
     <logical_identifier>urn:nasa:pds:context:telescope:canberra.dss42_34m</logical_identifier>
     <version_id>1.1</version_id>
-    <title>DSS 42 34-m Radio Telescope</title>
+    <title>DSS-42 34-m Radio Telescope</title>
     <information_model_version>1.22.0.0</information_model_version>
     <product_class>Product_Context</product_class>
     <Modification_History>


### PR DESCRIPTION
## 🗒️ Summary

* BHirsch added commets and investigations with references between the two.
* LNeakrase requested field_campaign.dd_nnss-nv_2019 and 8 pvmp*.
* DSimpson requested fixes to other_investigation.media.dsn and canberra.dss42_34m

## ⚙️ Test Data and/or Report
None.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


